### PR TITLE
Lesson 4.8.1

### DIFF
--- a/lib/custom_app_bar.dart
+++ b/lib/custom_app_bar.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final Widget? title;
+  final Color backgroundColor;
+  final Widget? leading;
+  final bool centerTitle;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight + 24);
+
+  const CustomAppBar({
+    super.key,
+    this.title,
+    required this.backgroundColor,
+    this.leading,
+    this.centerTitle = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: title,
+      centerTitle: centerTitle,
+      backgroundColor: backgroundColor,
+      elevation: 0,
+      toolbarHeight: 64,
+      titleSpacing: 16,
+      leading: leading,
+    );
+  }
+}

--- a/lib/ui/sight_card.dart
+++ b/lib/ui/sight_card.dart
@@ -58,28 +58,31 @@ class SightCard extends StatelessWidget {
                   ),
                 ),
               ),
-              Container(
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      sight.name,
-                      style: const TextStyle(
-                        color: Colors.black,
-                        fontWeight: FontWeight.bold,
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 250),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        sight.name,
+                        style: const TextStyle(
+                          color: Colors.black,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 5),
-                    Text(
-                      sight.details,
-                      maxLines: 2,
-                      style: const TextStyle(
-                        color: Colors.grey,
+                      const SizedBox(height: 5),
+                      Text(
+                        sight.details,
+                        maxLines: 2,
+                        style: const TextStyle(
+                          color: Colors.grey,
+                        ),
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/lib/ui/sight_card.dart
+++ b/lib/ui/sight_card.dart
@@ -15,7 +15,7 @@ class SightCard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Container(
-          margin: const EdgeInsets.only(bottom: 20, top: 20),
+          margin: const EdgeInsets.symmetric(vertical: 20),
           width: double.infinity,
           decoration: const BoxDecoration(
             borderRadius: BorderRadius.all(Radius.circular(15)),

--- a/lib/ui/sight_card.dart
+++ b/lib/ui/sight_card.dart
@@ -10,82 +10,85 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 20, top: 20),
-        width: double.infinity,
-        decoration: const BoxDecoration(
-          borderRadius: BorderRadius.all(Radius.circular(15)),
-          color: Color(0xFFF5F5F5),
-        ),
-        clipBehavior: Clip.hardEdge,
-        child: InkWell(
-          onTap: () => Navigator.push(
-            context,
-            MaterialPageRoute<SightDetailsCard>(
-              fullscreenDialog: true,
-              builder: (context) => SightDetailsCard(
-                sight: sight,
+    return AspectRatio(
+      aspectRatio: 3 / 2,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Container(
+          margin: const EdgeInsets.only(bottom: 20, top: 20),
+          width: double.infinity,
+          decoration: const BoxDecoration(
+            borderRadius: BorderRadius.all(Radius.circular(15)),
+            color: Color(0xFFF5F5F5),
+          ),
+          clipBehavior: Clip.hardEdge,
+          child: InkWell(
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute<SightDetailsCard>(
+                fullscreenDialog: true,
+                builder: (context) => SightDetailsCard(
+                  sight: sight,
+                ),
               ),
             ),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                color: Colors.indigo,
-                height: 100,
-                child: Container(
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            sight.type.name,
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                          Container(
-                            width: 20,
-                            height: 20,
-                            color: Colors.redAccent,
-                          ),
-                        ],
-                      ),
-                    ],
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  color: Colors.indigo,
+                  height: 100,
+                  child: Container(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              sight.type.name,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                            Container(
+                              width: 20,
+                              height: 20,
+                              color: Colors.redAccent,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 250),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        sight.name,
-                        style: const TextStyle(
-                          color: Colors.black,
-                          fontWeight: FontWeight.bold,
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 250),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          sight.name,
+                          style: const TextStyle(
+                            color: Colors.black,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 5),
-                      Text(
-                        sight.details,
-                        maxLines: 2,
-                        style: const TextStyle(
-                          color: Colors.grey,
+                        const SizedBox(height: 5),
+                        Text(
+                          sight.details,
+                          maxLines: 2,
+                          style: const TextStyle(
+                            color: Colors.grey,
+                          ),
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/sight_details_card.dart
+++ b/lib/ui/sight_details_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/constants/domain/sight_types.dart';
+import 'package:places/custom_app_bar.dart';
 import 'package:places/domain/sight.dart';
 
 class SightDetailsCard extends StatelessWidget {
@@ -113,8 +114,7 @@ class SightDetailsCard extends StatelessWidget {
             top: 0,
             left: 0,
             right: 0,
-            child: AppBar(
-              elevation: 0,
+            child: CustomAppBar(
               backgroundColor: Colors.transparent,
               leading: Padding(
                 padding: const EdgeInsets.all(8.0),

--- a/lib/ui/sight_list_screen.dart
+++ b/lib/ui/sight_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:places/custom_app_bar.dart';
 import 'package:places/mocks.dart';
 import 'package:places/ui/sight_card.dart';
 
@@ -15,34 +16,10 @@ class _SightListScreenState extends State<SightListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: RichText(
-          text: const TextSpan(
-            style: TextStyle(
-              color: Colors.black,
-              fontFamily: 'Roboto',
-              fontWeight: FontWeight.w700,
-              fontSize: 32,
-            ),
-            children: [
-              TextSpan(
-                text: 'С',
-                style: TextStyle(color: Colors.green),
-              ),
-              TextSpan(text: 'писок\n'),
-              TextSpan(
-                text: 'и',
-                style: TextStyle(color: Colors.yellow),
-              ),
-              TextSpan(text: 'нтересных мест'),
-            ],
-          ),
-        ),
+      appBar: CustomAppBar(
+        title: const AppBarTitleSightList(),
         centerTitle: false,
         backgroundColor: _backgroundColor,
-        elevation: 0,
-        toolbarHeight: 64,
-        titleSpacing: 16,
       ),
       backgroundColor: _backgroundColor,
       body: SingleChildScrollView(
@@ -51,6 +28,38 @@ class _SightListScreenState extends State<SightListScreen> {
             return SightCard(sight: sight);
           }).toList(),
         ),
+      ),
+    );
+  }
+}
+
+class AppBarTitleSightList extends StatelessWidget {
+  const AppBarTitleSightList({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return RichText(
+      text: const TextSpan(
+        style: TextStyle(
+          color: Colors.black,
+          fontFamily: 'Roboto',
+          fontWeight: FontWeight.w700,
+          fontSize: 32,
+        ),
+        children: [
+          TextSpan(
+            text: 'С',
+            style: TextStyle(color: Colors.green),
+          ),
+          TextSpan(text: 'писок\n'),
+          TextSpan(
+            text: 'и',
+            style: TextStyle(color: Colors.yellow),
+          ),
+          TextSpan(text: 'нтересных мест'),
+        ],
       ),
     );
   }


### PR DESCRIPTION
> В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер виджета Text поменялся? После выполнения,  отрегулируйте размер текста согласно дизайну.

Потому что ограничения сверху спустились

> Добавьте отступ между между фотографиями и описанием с помощью SizedBox

Уже пользовался для этих нужд

> AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2

Особой разницы не заметил, все эксперименты привели к переполнению. Хотя логика понятна, но на практике не особо понял как использовать

> Переверстать AppBar через наследника PreferredSizeWidget.

Сделал кастомный бар с наследованием размера от оригинального, но есть лееееегко подозрение, что я делаю что-то не то и не так, думается это как-то по-другому стоит организовывать 🤔 
