### PR TITLE
Lesson 4.10.2

### DIFF
--- a/lib/ui/sight_card.dart
+++ b/lib/ui/sight_card.dart
@@ -3,6 +3,8 @@ import 'package:places/constants/domain/sight_types.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/ui/sight_details_card.dart';
 
+import 'package:places/utils/loading_builder.dart';
+
 class SightCard extends StatelessWidget {
   final Sight sight;
 
@@ -40,20 +42,7 @@ class SightCard extends StatelessWidget {
                       sight.url,
                       fit: BoxFit.cover,
                       width: double.infinity,
-                      loadingBuilder: (context, child, loadingProgress) {
-                        if (loadingProgress == null) {
-                          return child;
-                        }
-
-                        return Center(
-                          child: CircularProgressIndicator(
-                            value: loadingProgress.expectedTotalBytes != null
-                                ? loadingProgress.cumulativeBytesLoaded /
-                                    loadingProgress.expectedTotalBytes!
-                                : null,
-                          ),
-                        );
-                      },
+                      loadingBuilder: loadingBuilder,
                     ),
                     Container(
                       padding: const EdgeInsets.all(20),

--- a/lib/ui/sight_details_card.dart
+++ b/lib/ui/sight_details_card.dart
@@ -21,10 +21,10 @@ class SightDetailsCard extends StatelessWidget {
               children: [
                 SizedBox(
                   height: 360,
+                  width: double.infinity,
                   child: Image.network(
                     sight.url,
                     fit: BoxFit.cover,
-                    width: double.infinity,
                     loadingBuilder: loadingBuilder,
                   ),
                 ),

--- a/lib/ui/sight_details_card.dart
+++ b/lib/ui/sight_details_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:places/constants/domain/sight_types.dart';
 import 'package:places/custom_app_bar.dart';
 import 'package:places/domain/sight.dart';
+import 'package:places/utils/loading_builder.dart';
 
 class SightDetailsCard extends StatelessWidget {
   final Sight sight;
@@ -23,20 +24,7 @@ class SightDetailsCard extends StatelessWidget {
                   fit: BoxFit.cover,
                   height: 360,
                   width: double.infinity,
-                  loadingBuilder: (context, child, loadingProgress) {
-                    if (loadingProgress == null) {
-                      return child;
-                    }
-
-                    return Center(
-                      child: CircularProgressIndicator(
-                        value: loadingProgress.expectedTotalBytes != null
-                            ? loadingProgress.cumulativeBytesLoaded /
-                                loadingProgress.expectedTotalBytes!
-                            : null,
-                      ),
-                    );
-                  },
+                  loadingBuilder: loadingBuilder,
                 ),
                 const SizedBox(height: 24),
                 Container(

--- a/lib/ui/sight_details_card.dart
+++ b/lib/ui/sight_details_card.dart
@@ -19,12 +19,14 @@ class SightDetailsCard extends StatelessWidget {
           SingleChildScrollView(
             child: Column(
               children: [
-                Image.network(
-                  sight.url,
-                  fit: BoxFit.cover,
+                SizedBox(
                   height: 360,
-                  width: double.infinity,
-                  loadingBuilder: loadingBuilder,
+                  child: Image.network(
+                    sight.url,
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                    loadingBuilder: loadingBuilder,
+                  ),
                 ),
                 const SizedBox(height: 24),
                 Container(

--- a/lib/ui/sight_details_card.dart
+++ b/lib/ui/sight_details_card.dart
@@ -122,8 +122,8 @@ class SightDetailsCard extends StatelessWidget {
             right: 0,
             child: CustomAppBar(
               backgroundColor: Colors.transparent,
-              leading: Padding(
-                padding: const EdgeInsets.all(8.0),
+              leading: Container(
+                margin: const EdgeInsets.only(left: 8, top: 16),
                 child: DecoratedBox(
                   decoration: BoxDecoration(
                     color: Colors.white,

--- a/lib/ui/sight_details_card.dart
+++ b/lib/ui/sight_details_card.dart
@@ -18,9 +18,25 @@ class SightDetailsCard extends StatelessWidget {
           SingleChildScrollView(
             child: Column(
               children: [
-                Container(
-                  color: const Color(0xffeeee00),
-                  height: 360.0,
+                Image.network(
+                  sight.url,
+                  fit: BoxFit.cover,
+                  height: 360,
+                  width: double.infinity,
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) {
+                      return child;
+                    }
+
+                    return Center(
+                      child: CircularProgressIndicator(
+                        value: loadingProgress.expectedTotalBytes != null
+                            ? loadingProgress.cumulativeBytesLoaded /
+                                loadingProgress.expectedTotalBytes!
+                            : null,
+                      ),
+                    );
+                  },
                 ),
                 const SizedBox(height: 24),
                 Container(

--- a/lib/utils/loading_builder.dart
+++ b/lib/utils/loading_builder.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+Widget loadingBuilder(
+  BuildContext context,
+  Widget child,
+  ImageChunkEvent? loadingProgress,
+) {
+  if (loadingProgress == null) {
+    return child;
+  }
+
+  return Center(
+    child: CircularProgressIndicator(
+      value: loadingProgress.expectedTotalBytes != null
+          ? loadingProgress.cumulativeBytesLoaded /
+              loadingProgress.expectedTotalBytes!
+          : null,
+    ),
+  );
+}

--- a/lib/utils/loading_builder.dart
+++ b/lib/utils/loading_builder.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 
-const double kLoadingProgressIndicatorSize = 24.0;
-const int kDefaultExpectedTotalBytes = -1;
-
 Widget loadingBuilder(
   BuildContext context,
   Widget child,
@@ -20,10 +17,7 @@ Widget loadingBuilder(
     child: Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        CircularProgressIndicator(
-          value: progress,
-          strokeWidth: kLoadingProgressIndicatorSize / 4,
-        ),
+        CircularProgressIndicator(value: progress),
         const SizedBox(height: 8),
         Text('Загрузка $loadedPercent %'),
       ],

--- a/lib/utils/loading_builder.dart
+++ b/lib/utils/loading_builder.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+const double kLoadingProgressIndicatorSize = 24.0;
+const int kDefaultExpectedTotalBytes = -1;
+
 Widget loadingBuilder(
   BuildContext context,
   Widget child,
@@ -9,12 +12,21 @@ Widget loadingBuilder(
     return child;
   }
 
+  final expectedTotalBytes = loadingProgress.expectedTotalBytes;
+  final progress = loadingProgress.cumulativeBytesLoaded / expectedTotalBytes!;
+  final loadedPercent = (progress * 100).toInt();
+
   return Center(
-    child: CircularProgressIndicator(
-      value: loadingProgress.expectedTotalBytes != null
-          ? loadingProgress.cumulativeBytesLoaded /
-              loadingProgress.expectedTotalBytes!
-          : null,
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        CircularProgressIndicator(
+          value: progress,
+          strokeWidth: kLoadingProgressIndicatorSize / 4,
+        ),
+        const SizedBox(height: 8),
+        Text('Загрузка $loadedPercent %'),
+      ],
     ),
   );
 }


### PR DESCRIPTION
![Снимок экрана 2023-03-09 002911](https://user-images.githubusercontent.com/72388296/223854525-346c4f38-41a2-487f-9b3b-5d12f83540c7.png)


Хотел вынести индикатор загрузки, но вижу замечание от линтера Avoid returning widgets from a global function.

Как лучше поступать в таких случаях: куда именно можно вытащить общий лоадер?